### PR TITLE
bumped version numbers in examples for splines dependancy

### DIFF
--- a/examples/01-hello-world/Cargo.toml
+++ b/examples/01-hello-world/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hello-world"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Dimitri Sabadie <dimitri.sabadie@gmail.com>"]
 
 [dependencies]
-splines = "0.1"
+splines = "0.2"

--- a/examples/02-serialization/Cargo.toml
+++ b/examples/02-serialization/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "serialization"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Dimitri Sabadie <dimitri.sabadie@gmail.com>"]
 
 [dependencies]
 serde_json = "1"
 
 [dependencies.splines]
-version = "0.1"
+version = "0.2"
 features = ["serialization"]


### PR DESCRIPTION
bumped the versions for the examples to 0.2.0 and made them depend on the 0.2 version of splines.