### PR TITLE
Add impl-glam feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,14 @@ maintenance = { status = "actively-developed" }
 [features]
 default = ["std"]
 impl-cgmath = ["cgmath"]
+impl-glam = ["glam"]
 impl-nalgebra = ["nalgebra", "num-traits", "simba"]
 serialization = ["serde", "serde_derive"]
 std = []
 
 [dependencies]
 cgmath = { version = "0.17", optional = true }
+glam = { version = "0.9", optional = true }
 nalgebra = { version = ">=0.21, <0.23", optional = true }
 num-traits = { version = "0.2", optional = true }
 serde =  { version = "1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ std = []
 
 [dependencies]
 cgmath = { version = "0.17", optional = true }
-glam = { version = "0.9", optional = true }
+glam = { version = "0.10", optional = true }
 nalgebra = { version = ">=0.21, <0.23", optional = true }
 num-traits = { version = "0.2", optional = true }
 serde =  { version = "1", optional = true }

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ So here’s a list of currently supported features and how to enable them:
   - **[cgmath](https://crates.io/crates/cgmath) implementors.**
     - Adds some useful implementations of `Interpolate` for some cgmath types.
     - Enable with the `"impl-cgmath"` feature.
+  - **[glam](https://crates.io/crates/glam) implementors.**
+    - Adds some useful implementations of `Interpolate` for some glam types.
+    - Enable with the `"impl-glam"` feature.
   - **[nalgebra](https://crates.io/crates/nalgebra) implementors.**
     - Adds some useful implementations of `Interpolate` for some nalgebra types.
     - Enable with the `"impl-nalgebra"` feature.

--- a/src/glam.rs
+++ b/src/glam.rs
@@ -1,0 +1,88 @@
+use glam::{Quat, Vec2, Vec3, Vec3A, Vec4};
+
+use crate::interpolate::{
+  cubic_bezier_def, cubic_hermite_def, quadratic_bezier_def, Interpolate, Linear,
+};
+
+macro_rules! impl_interpolate_vec {
+  ($($t:tt)*) => {
+    impl Linear<f32> for $($t)* {
+      #[inline(always)]
+      fn outer_mul(self, t: f32) -> Self {
+        self * t
+      }
+
+      #[inline(always)]
+      fn outer_div(self, t: f32) -> Self {
+        self / t
+      }
+    }
+
+    impl Interpolate<f32> for $($t)* {
+      #[inline(always)]
+      fn lerp(a: Self, b: Self, t: f32) -> Self {
+        a.lerp(b, t)
+      }
+
+      #[inline(always)]
+      fn cubic_hermite(
+        x: (Self, f32),
+        a: (Self, f32),
+        b: (Self, f32),
+        y: (Self, f32),
+        t: f32,
+      ) -> Self {
+        cubic_hermite_def(x, a, b, y, t)
+      }
+
+      #[inline(always)]
+      fn quadratic_bezier(a: Self, u: Self, b: Self, t: f32) -> Self {
+        quadratic_bezier_def(a, u, b, t)
+      }
+
+      #[inline(always)]
+      fn cubic_bezier(a: Self, u: Self, v: Self, b: Self, t: f32) -> Self {
+        cubic_bezier_def(a, u, v, b, t)
+      }
+    }
+  }
+}
+
+impl_interpolate_vec!(Vec2);
+impl_interpolate_vec!(Vec3);
+impl_interpolate_vec!(Vec3A);
+impl_interpolate_vec!(Vec4);
+
+impl Linear<f32> for Quat {
+  #[inline(always)]
+  fn outer_mul(self, t: f32) -> Self {
+    self * t
+  }
+
+  #[inline(always)]
+  fn outer_div(self, t: f32) -> Self {
+    self / t
+  }
+}
+
+impl Interpolate<f32> for Quat {
+  #[inline(always)]
+  fn lerp(a: Self, b: Self, t: f32) -> Self {
+    a.lerp(b, t).normalize()
+  }
+
+  #[inline(always)]
+  fn cubic_hermite(x: (Self, f32), a: (Self, f32), b: (Self, f32), y: (Self, f32), t: f32) -> Self {
+    cubic_hermite_def(x, a, b, y, t)
+  }
+
+  #[inline(always)]
+  fn quadratic_bezier(a: Self, u: Self, b: Self, t: f32) -> Self {
+    quadratic_bezier_def(a, u, b, t)
+  }
+
+  #[inline(always)]
+  fn cubic_bezier(a: Self, u: Self, v: Self, b: Self, t: f32) -> Self {
+    cubic_bezier_def(a, u, v, b, t)
+  }
+}

--- a/src/glam.rs
+++ b/src/glam.rs
@@ -68,7 +68,7 @@ impl Linear<f32> for Quat {
 impl Interpolate<f32> for Quat {
   #[inline(always)]
   fn lerp(a: Self, b: Self, t: f32) -> Self {
-    a.lerp(b, t).normalize()
+    a.lerp(b, t)
   }
 
   #[inline(always)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,9 @@
 //!   - **[cgmath](https://crates.io/crates/cgmath) implementors.**
 //!     - Adds some useful implementations of `Interpolate` for some cgmath types.
 //!     - Enable with the `"impl-cgmath"` feature.
+//!   - **[glam](https://crates.io/crates/glam) implementors.**
+//!     - Adds some useful implementations of `Interpolate` for some glam types.
+//!     - Enable with the `"impl-glam"` feature.
 //!   - **[nalgebra](https://crates.io/crates/nalgebra) implementors.**
 //!     - Adds some useful implementations of `Interpolate` for some nalgebra types.
 //!     - Enable with the `"impl-nalgebra"` feature.
@@ -111,6 +114,8 @@ extern crate alloc;
 
 #[cfg(feature = "impl-cgmath")]
 mod cgmath;
+#[cfg(feature = "impl-glam")]
+mod glam;
 pub mod interpolate;
 pub mod interpolation;
 pub mod iter;


### PR DESCRIPTION
I'm trying to contribute to Bevy engine's animation support, and Bevy uses glam for its math types. Glam does not implement adding and subtracting Quats at this time, but I've opened a pull request to them as well. If they merge it, this should work too.