### PR TITLE
Provide better feature gates.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,15 +24,14 @@ default = ["std"]
 impl-cgmath = ["cgmath"]
 impl-glam = ["glam"]
 impl-nalgebra = ["nalgebra"]
-serialization = ["serde", "serde_derive"]
+serialization = ["serde"]
 std = []
 
 [dependencies]
 cgmath = { version = ">=0.17, <0.19", optional = true }
 glam = { version = ">=0.10, <0.15", optional = true }
 nalgebra = { version = ">=0.21, <0.25", optional = true }
-serde =  { version = "1", optional = true }
-serde_derive = { version = "1", optional = true }
+serde =  { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 float-cmp = ">=0.6, < 0.9"
@@ -46,4 +45,4 @@ name = "hello-world"
 
 [[example]]
 name = "serialization"
-required-features = ["serialization"]
+required-features = ["serde"]

--- a/README.md
+++ b/README.md
@@ -83,19 +83,19 @@ not. It’s especially important to see how it copes with the documentation.
 
 So here’s a list of currently supported features and how to enable them:
 
-  - **Serialization / deserialization.**
+  - **Serde.**
     - This feature implements both the `Serialize` and `Deserialize` traits from `serde` for all
       types exported by this crate.
-    - Enable with the `"serialization"` feature.
+    - Enable with the `"serde"` feature.
   - **[cgmath](https://crates.io/crates/cgmath) implementors.**
     - Adds some useful implementations of `Interpolate` for some cgmath types.
-    - Enable with the `"impl-cgmath"` feature.
+    - Enable with the `"cgmath"` feature.
   - **[glam](https://crates.io/crates/glam) implementors.**
     - Adds some useful implementations of `Interpolate` for some glam types.
-    - Enable with the `"impl-glam"` feature.
+    - Enable with the `"glam"` feature.
   - **[nalgebra](https://crates.io/crates/nalgebra) implementors.**
     - Adds some useful implementations of `Interpolate` for some nalgebra types.
-    - Enable with the `"impl-nalgebra"` feature.
+    - Enable with the `"nalgebra"` feature.
   - **Standard library / no standard library.**
     - It’s possible to compile against the standard library or go on your own without it.
     - Compiling with the standard library is enabled by default.

--- a/src/interpolation.rs
+++ b/src/interpolation.rs
@@ -1,7 +1,7 @@
 //! Available interpolation modes.
 
-#[cfg(feature = "serialization")]
-use serde_derive::{Deserialize, Serialize};
+#[cfg(any(feature = "serialization", feature = "serde"))]
+use serde::{Deserialize, Serialize};
 
 /// Available kind of interpolations.
 ///
@@ -9,7 +9,7 @@ use serde_derive::{Deserialize, Serialize};
 #[non_exhaustive]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
-  feature = "serialization",
+  any(feature = "serialization", feature = "serde"),
   derive(Deserialize, Serialize),
   serde(rename_all = "snake_case")
 )]

--- a/src/key.rs
+++ b/src/key.rs
@@ -7,8 +7,8 @@
 //! interpolation mode on a key-based way, allowing you to implement and encode complex curves.
 
 use crate::interpolation::Interpolation;
-#[cfg(feature = "serialization")]
-use serde_derive::{Deserialize, Serialize};
+#[cfg(any(feature = "serialization", feature = "serde"))]
+use serde::{Deserialize, Serialize};
 
 /// A spline control point.
 ///
@@ -19,7 +19,7 @@ use serde_derive::{Deserialize, Serialize};
 /// [`Interpolation`]: crate::interpolation::Interpolation
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
-  feature = "serialization",
+  any(feature = "serialization", feature = "serde"),
   derive(Deserialize, Serialize),
   serde(rename_all = "snake_case")
 )]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,19 +84,19 @@
 //!
 //! So here’s a list of currently supported features and how to enable them:
 //!
-//!   - **Serialization / deserialization.**
+//!   - **Serde.**
 //!     - This feature implements both the `Serialize` and `Deserialize` traits from `serde` for all
 //!       types exported by this crate.
-//!     - Enable with the `"serialization"` feature.
+//!     - Enable with the `"serde"` feature.
 //!   - **[cgmath](https://crates.io/crates/cgmath) implementors.**
 //!     - Adds some useful implementations of `Interpolate` for some cgmath types.
-//!     - Enable with the `"impl-cgmath"` feature.
+//!     - Enable with the `"cgmath"` feature.
 //!   - **[glam](https://crates.io/crates/glam) implementors.**
 //!     - Adds some useful implementations of `Interpolate` for some glam types.
-//!     - Enable with the `"impl-glam"` feature.
+//!     - Enable with the `"glam"` feature.
 //!   - **[nalgebra](https://crates.io/crates/nalgebra) implementors.**
 //!     - Adds some useful implementations of `Interpolate` for some nalgebra types.
-//!     - Enable with the `"impl-nalgebra"` feature.
+//!     - Enable with the `"nalgebra"` feature.
 //!   - **Standard library / no standard library.**
 //!     - It’s possible to compile against the standard library or go on your own without it.
 //!     - Compiling with the standard library is enabled by default.
@@ -112,15 +112,15 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
-#[cfg(feature = "impl-cgmath")]
+#[cfg(any(feature = "impl-cgmath", feature = "cgmath"))]
 mod cgmath;
-#[cfg(feature = "impl-glam")]
+#[cfg(any(feature = "impl-glam", feature = "glam"))]
 mod glam;
 pub mod interpolate;
 pub mod interpolation;
 pub mod iter;
 pub mod key;
-#[cfg(feature = "impl-nalgebra")]
+#[cfg(any(feature = "impl-nalgebra", feature = "nalgebra"))]
 mod nalgebra;
 pub mod spline;
 

--- a/src/spline.rs
+++ b/src/spline.rs
@@ -10,8 +10,8 @@ use alloc::vec::Vec;
 use core::cmp::Ordering;
 #[cfg(not(feature = "std"))]
 use core::ops::{Div, Mul};
-#[cfg(feature = "serialization")]
-use serde_derive::{Deserialize, Serialize};
+#[cfg(any(feature = "serialization", feature = "serde"))]
+use serde::{Deserialize, Serialize};
 #[cfg(feature = "std")]
 use std::cmp::Ordering;
 
@@ -28,7 +28,10 @@ use std::cmp::Ordering;
 ///   - [`Spline::clamped_sample`]: behaves like [`Spline::sample`] but will return either the first
 ///     or last key if out of bound; it will return `None` if not enough key.
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
+#[cfg_attr(
+  any(feature = "serialization", feature = "serde"),
+  derive(Deserialize, Serialize)
+)]
 pub struct Spline<T, V>(pub(crate) Vec<Key<T, V>>);
 
 impl<T, V> Spline<T, V> {


### PR DESCRIPTION
- `serialization` becomes `serde`.
- `impl-nalgebra` becomes `nalgebra`.
- `impl-cgmath` becomes `cgmath`.
- `impl-glam` becomes `glam`.

Already existing feature gates are kept around so that we don’t
introduce a breaking change.